### PR TITLE
create a new path in the image service to serve the upload page

### DIFF
--- a/chapter3/imageService/src/main/java/course/cloud/computing/rest/ImageService.java
+++ b/chapter3/imageService/src/main/java/course/cloud/computing/rest/ImageService.java
@@ -74,6 +74,33 @@ public class ImageService {
 			}
 		}).build();
 	}
+
+    @GET
+    @Path("upload")
+    @Produces("text/html")
+    public Response uploadPage() {
+        InputStream pageStream = ImageService.class.getResourceAsStream("/upload.html");
+        if(pageStream == null) {
+            return Response.serverError().build();
+        }
+        final byte[] page;
+        try {
+            page = IOUtils.toByteArray(pageStream);
+        } catch (IOException e) {
+            return  Response.serverError().build();
+        }
+
+        return Response.ok().entity(new StreamingOutput() {
+                                @Override
+                                public void write(OutputStream output) throws
+                                        IOException, WebApplicationException {
+
+                                    output.write(page);
+                                    output.flush();
+                                }
+                    }
+        ).build();
+    }
 	
 	@GET
 	@Path("{name}")
@@ -88,7 +115,7 @@ public class ImageService {
     }
 
 	@POST
-	@Consumes("image/jpeg, image/jpg")
+	@Consumes("image/jpeg")
 	public Response upload(InputStream in,
 			@HeaderParam("Content-Type") String fileType,
 			@HeaderParam("Content-Length") long fileSize) throws IOException {
@@ -108,6 +135,7 @@ public class ImageService {
 		} else {
 			fileName += ".png";
 		}
+        System.out.println("Set new filename to " + fileName);
 
 		File directory = new File("images");
 		if (!directory.isDirectory()) {

--- a/chapter3/imageService/src/main/resources/upload.html
+++ b/chapter3/imageService/src/main/resources/upload.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html>
+<head>
+    <title>Image Upload</title>
+    <meta charset="UTF-8">
+    <script script="text/javascript">
+        var BASE_URL = "http://localhost:9090/myapp/img";
+
+        onload = function () {
+            document.getElementById("submit").onclick = uploadFile;
+        };
+
+        function uploadFile() {
+
+            document.getElementById("status").innerHTML = "making http call ... ";
+
+            var file = document.getElementById("filechooser").files[0];
+            var extension = file.name.split(".").pop();
+
+            var type;
+            if (extension === "jpg" || extension === "jpeg" ||
+                    extension === "JPG" || extension === "JPEG") {
+                type = "image/jpeg";
+            } else if (extension === "png" || extension === "PNG") {
+                type = "image/png";
+            } else {
+                document.getElementById("status").innerHTML = "Invalid file type";
+                return;
+            }
+
+            try {
+                var request = new XMLHttpRequest();
+                request.open("POST", BASE_URL, true);
+                request.onload = function () {
+                    if (request.status === 201) {
+                        var fileName = request.getResponseHeader("Location").split("/").pop();
+                        document.getElementById("status").innerHTML = "File created with name " + fileName;
+                        alert('Loaded');
+                    } else {
+                        document.getElementById("status").innerHTML = "Error creating file: (" + request.status + ") " + request.responseText;
+                        alert('Error');
+                    }
+                };
+
+                request.setRequestHeader("Content-Type", type);
+                request.send(file);
+            } catch (err) {
+                alert(err);
+                document.getElementById("status").innerHTML += "\nXMLHttprequest error: " + err.description;
+            }
+        }
+    </script>
+</head>
+<body>
+<form>
+    <p>Upload image through a web service</p>
+    <input type="file" id="filechooser">
+    <button type="button" id="submit">Upload</button>
+</form>
+<p>Status:</p>
+
+<p id="status"></p>
+</body>
+</html>


### PR DESCRIPTION
Deepa and I were playing with the examples and noticed that browser XSS protection was preventing a cross-domain AJAX call in the image example.  We wrote a quick endpoint in the ImageService that serves the upload webpage (lazily), to prevent cross-domain protection problems.
